### PR TITLE
Integrate teachers page

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1,7 +1,25 @@
-from PyQt6.QtWidgets import QMainWindow
+from PyQt6.QtWidgets import QMainWindow, QWidget
 from PyQt6 import uic
+
+
+class TeacherItem(QWidget):
+    def __init__(self, index=1, parent=None):
+        super().__init__(parent)
+        uic.loadUi("teachersItem.ui", self)
+        self.index_label.setText(str(index))
 
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         uic.loadUi("main_window.ui", self)
+
+        self.teachers_page = uic.loadUi("teachers.ui")
+        self.stackedWidget.addWidget(self.teachers_page)
+        self.teachers_page.teachersListLayout.addWidget(TeacherItem())
+
+        self.teachers_btn_1.toggled.connect(self._show_teachers)
+        self.teachers_btn_2.toggled.connect(self._show_teachers)
+
+    def _show_teachers(self, checked):
+        if checked:
+            self.stackedWidget.setCurrentWidget(self.teachers_page)


### PR DESCRIPTION
## Summary
- load teachersItem.ui as `TeacherItem`
- add teachers page from `teachers.ui` to the stacked widget
- show the teachers page when the sidebar button is toggled

## Testing
- `python3 main.py` *(fails: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_687d123a911c832c90dd729d5c8c1eea