### PR TITLE
Fix add teacher button

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1,12 +1,7 @@
-from PyQt6.QtWidgets import QMainWindow, QWidget
+from PyQt6.QtWidgets import QMainWindow
 from PyQt6 import uic
 
-
-class TeacherItem(QWidget):
-    def __init__(self, index=1, parent=None):
-        super().__init__(parent)
-        uic.loadUi("teachersItem.ui", self)
-        self.index_label.setText(str(index))
+from teacher_item import TeacherItem
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -17,9 +12,15 @@ class MainWindow(QMainWindow):
         self.stackedWidget.addWidget(self.teachers_page)
         self.teachers_page.teachersListLayout.addWidget(TeacherItem())
 
+        self.teachers_page.add_btn.clicked.connect(self._add_teacher)
+
         self.teachers_btn_1.toggled.connect(self._show_teachers)
         self.teachers_btn_2.toggled.connect(self._show_teachers)
 
     def _show_teachers(self, checked):
         if checked:
             self.stackedWidget.setCurrentWidget(self.teachers_page)
+
+    def _add_teacher(self):
+        index = self.teachers_page.teachersListLayout.count() + 1
+        self.teachers_page.teachersListLayout.addWidget(TeacherItem(index))

--- a/teacher_item.py
+++ b/teacher_item.py
@@ -1,0 +1,9 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6 import uic
+
+
+class TeacherItem(QWidget):
+    def __init__(self, index=1, parent=None):
+        super().__init__(parent)
+        uic.loadUi("teachersItem.ui", self)
+        self.index_label.setText(str(index))


### PR DESCRIPTION
## Summary
- split TeacherItem widget into separate module
- add handler for `+` button to create new TeacherItem widgets

## Testing
- `python3 -m py_compile main.py teacher_item.py main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_687d13ce0ce0832ca96d580c3ef5258c