### PR TITLE
Implement teacher management UI with DB persistence

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,54 @@
+import json
+import sqlite3
+
+DB_FILE = "teachers.db"
+
+
+def _get_connection():
+    conn = sqlite3.connect(DB_FILE)
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS teachers(
+               id INTEGER PRIMARY KEY,
+               is_active INTEGER,
+               name TEXT,
+               subjects TEXT
+           )"""
+    )
+    return conn
+
+
+def load_teachers():
+    conn = _get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT id, is_active, name, subjects FROM teachers ORDER BY id")
+    teachers = []
+    for row in cur.fetchall():
+        subjects = json.loads(row[3]) if row[3] else []
+        teachers.append(
+            {
+                "id": row[0],
+                "is_active": bool(row[1]),
+                "name": row[2] or "",
+                "subjects": subjects,
+            }
+        )
+    conn.close()
+    return teachers
+
+
+def save_teachers(teachers):
+    conn = _get_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM teachers")
+    for teacher in teachers:
+        cur.execute(
+            "INSERT INTO teachers(id, is_active, name, subjects) VALUES (?, ?, ?, ?)",
+            (
+                teacher.get("id"),
+                int(teacher.get("is_active", True)),
+                teacher.get("name", ""),
+                json.dumps(teacher.get("subjects", [])),
+            ),
+        )
+    conn.commit()
+    conn.close()

--- a/main_window.py
+++ b/main_window.py
@@ -1,26 +1,27 @@
 from PyQt6.QtWidgets import QMainWindow
 from PyQt6 import uic
 
-from teacher_item import TeacherItem
+from teachers_page import TeachersPage
+
 
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         uic.loadUi("main_window.ui", self)
 
-        self.teachers_page = uic.loadUi("teachers.ui")
+        self.teachers_page = TeachersPage()
         self.stackedWidget.addWidget(self.teachers_page)
-        self.teachers_page.teachersListLayout.addWidget(TeacherItem())
-
-        self.teachers_page.add_btn.clicked.connect(self._add_teacher)
 
         self.teachers_btn_1.toggled.connect(self._show_teachers)
         self.teachers_btn_2.toggled.connect(self._show_teachers)
+        self.search_btn.clicked.connect(self._search)
+        self.search_input.returnPressed.connect(self._search)
 
-    def _show_teachers(self, checked):
+    def _show_teachers(self, checked: bool):
         if checked:
             self.stackedWidget.setCurrentWidget(self.teachers_page)
 
-    def _add_teacher(self):
-        index = self.teachers_page.teachersListLayout.count() + 1
-        self.teachers_page.teachersListLayout.addWidget(TeacherItem(index))
+    def _search(self):
+        text = self.search_input.text()
+        if self.stackedWidget.currentWidget() == self.teachers_page:
+            self.teachers_page.search(text)

--- a/teacher_item.py
+++ b/teacher_item.py
@@ -1,9 +1,66 @@
-from PyQt6.QtWidgets import QWidget
+from PyQt6.QtWidgets import QWidget, QListWidgetItem
+from PyQt6.QtCore import pyqtSignal
 from PyQt6 import uic
 
 
 class TeacherItem(QWidget):
-    def __init__(self, index=1, parent=None):
+    """Widget representing one teacher in the list."""
+
+    delete_requested = pyqtSignal(QWidget)
+
+    SUBJECTS = [
+        "Математика",
+        "Физика",
+        "Информатика",
+        "Химия",
+        "История",
+    ]
+
+    def __init__(self, index: int = 1, parent=None):
         super().__init__(parent)
         uic.loadUi("teachersItem.ui", self)
+        self.set_index(index)
+        self.isActive_checkbox.setChecked(True)
+        self.subjects_comboBox.addItems(self.SUBJECTS)
+        self.add_subject_btn.setText("+")
+        self.delete_btn.setText("Удалить")
+
+        self.add_subject_btn.clicked.connect(self._add_subject)
+        self.delete_btn.clicked.connect(lambda: self.delete_requested.emit(self))
+        self.subject_list.itemDoubleClicked.connect(self._remove_subject)
+
+    def set_index(self, index: int) -> None:
         self.index_label.setText(str(index))
+
+    def _add_subject(self):
+        subject = self.subjects_comboBox.currentText()
+        if not subject:
+            return
+        for i in range(self.subject_list.count()):
+            if self.subject_list.item(i).text() == subject:
+                return
+        self.subject_list.addItem(subject)
+
+    def _remove_subject(self, item: QListWidgetItem):
+        row = self.subject_list.row(item)
+        self.subject_list.takeItem(row)
+
+    def get_data(self) -> dict:
+        subjects = [self.subject_list.item(i).text() for i in range(self.subject_list.count())]
+        return {
+            "id": int(self.index_label.text()),
+            "is_active": self.isActive_checkbox.isChecked(),
+            "name": self.name_edit.text(),
+            "subjects": subjects,
+        }
+
+    def set_data(self, data: dict) -> None:
+        self.set_index(data.get("id", 1))
+        self.isActive_checkbox.setChecked(data.get("is_active", True))
+        self.name_edit.setText(data.get("name", ""))
+        for subj in data.get("subjects", []):
+            self.subject_list.addItem(subj)
+
+    def matches(self, text: str) -> bool:
+        text = text.lower()
+        return text in self.name_edit.text().lower() or text == self.index_label.text()

--- a/teachers.ui
+++ b/teachers.ui
@@ -2,71 +2,32 @@
 <ui version="4.0">
  <class>Form</class>
  <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>300</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <widget class="QWidget" name="verticalLayoutWidget_2">
-   <property name="geometry">
-    <rect>
-     <x>70</x>
-     <y>50</y>
-     <width>301</width>
-     <height>151</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QScrollArea" name="scrollArea">
-      <property name="widgetResizable">
-       <bool>true</bool>
-      </property>
-      <widget class="QWidget" name="scrollAreaWidgetContents">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>297</width>
-         <height>87</height>
-        </rect>
-       </property>
-       <widget class="QWidget" name="verticalLayoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>301</width>
-          <height>91</height>
-         </rect>
-        </property>
-        <layout class="QVBoxLayout" name="teachersListLayout"/>
-       </widget>
-      </widget>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <layout class="QVBoxLayout" name="teachersListLayout"/>
      </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="add_btn">
-      <property name="text">
-       <string>+</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QPushButton" name="save_btn">
-      <property name="text">
-       <string>Сохранить</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="add_btn">
+     <property name="text">
+      <string>+</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="save_btn">
+     <property name="text">
+      <string>Сохранить</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/teachersItem.ui
+++ b/teachersItem.ui
@@ -2,66 +2,59 @@
 <ui version="4.0">
  <class>Form</class>
  <widget class="QWidget" name="Form">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>400</width>
-    <height>188</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <widget class="QWidget" name="horizontalLayoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>90</y>
-     <width>396</width>
-     <height>80</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout">
-    <item>
-     <widget class="QLabel" name="index_label">
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QCheckBox" name="isActive_checkbox">
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QLineEdit" name="name_edit"/>
-    </item>
-    <item>
-     <widget class="QComboBox" name="subjects_comboBox"/>
-    </item>
-    <item>
-     <widget class="QPushButton" name="add_subject_btn">
-      <property name="text">
-       <string>PushButton</string>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QListWidget" name="subject_list"/>
-    </item>
-    <item>
-     <widget class="QPushButton" name="delete_btn">
-      <property name="text">
-       <string>PushButton</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <widget class="QLabel" name="index_label">
+     <property name="minimumWidth">
+      <number>20</number>
+     </property>
+     <property name="text">
+      <string>1</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="isActive_checkbox">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="name_edit">
+     <property name="placeholderText">
+      <string>ФИО</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="subjects_comboBox"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="add_subject_btn">
+     <property name="text">
+      <string>+</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="subject_list">
+     <property name="maximumHeight">
+      <number>60</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="delete_btn">
+     <property name="text">
+      <string>Удалить</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/teachers_page.py
+++ b/teachers_page.py
@@ -1,0 +1,66 @@
+from PyQt6.QtWidgets import QWidget
+from PyQt6 import uic
+
+import db
+from teacher_item import TeacherItem
+
+
+class TeachersPage(QWidget):
+    """Page widget managing the list of teachers."""
+
+    def __init__(self):
+        super().__init__()
+        uic.loadUi("teachers.ui", self)
+        self._items = []
+
+        self.add_btn.clicked.connect(self.add_teacher)
+        self.save_btn.clicked.connect(self.save)
+
+        self.load()
+
+    # ---------------------------------------------------------
+    def load(self):
+        """Load teachers from database."""
+        for item in self._items:
+            self.teachersListLayout.removeWidget(item)
+            item.deleteLater()
+        self._items = []
+
+        records = db.load_teachers()
+        if not records:
+            self.add_teacher()
+            return
+        for rec in records:
+            self.add_teacher(rec)
+
+    def save(self):
+        """Save all teachers to database."""
+        data = [item.get_data() for item in self._items]
+        db.save_teachers(data)
+
+    # ---------------------------------------------------------
+    def add_teacher(self, data: dict | None = None):
+        index = len(self._items) + 1
+        item = TeacherItem(index)
+        item.delete_requested.connect(self._remove_item)
+        if data:
+            item.set_data(data)
+        self._items.append(item)
+        self.teachersListLayout.addWidget(item)
+
+    def _remove_item(self, item: TeacherItem):
+        self.teachersListLayout.removeWidget(item)
+        item.deleteLater()
+        self._items.remove(item)
+        self._refresh_indexes()
+
+    def _refresh_indexes(self):
+        for idx, item in enumerate(self._items, 1):
+            item.set_index(idx)
+
+    # ---------------------------------------------------------
+    def search(self, text: str):
+        """Show only items that match the search text."""
+        text = text.lower().strip()
+        for item in self._items:
+            item.setVisible(not text or item.matches(text))


### PR DESCRIPTION
## Summary
- rebuild teacher item widget to allow editing name, active state and multiple subjects
- redesign teachers list page and load/save teachers in SQLite database
- connect search from the main window to filter teachers
- add helper module `db.py`

## Testing
- `python3 -m py_compile main.py main_window.py teacher_item.py teachers_page.py db.py`
- `python3 - <<'EOF'
import db
print(db.load_teachers())
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687d1b8e9aa8832c95586bffefe03b02